### PR TITLE
Harden nuget workflow: drop persisted git credentials and restrict token

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -8,6 +8,11 @@ on:
       - src/version.props
       - .github/workflows/nuget.yml
 
+# The job only checks out the repository and pushes the package to nuget.org, which is authenticated
+# with NUGET_API_KEY rather than the job token, so read access to the contents is all it needs.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6


### PR DESCRIPTION
Addresses Aikido finding **362138487** (group 33562783, LOW / score 30): *"GitHub Action actions/checkout persist Git credentials in workflow"*.

## What changed
`.github/workflows/nuget.yml`:
- Added `persist-credentials: false` to the `actions/checkout` step.
- Added a top-level `permissions: contents: read` block (the file had none, and the org default workflow permission is **write**).

No action versions were changed — Dependabot owns those.

## Why this is safe
- The workflow performs **no git write operation** after checkout: no push, commit, tag, or PR creation.
- Publishing is authenticated with `secrets.NUGET_API_KEY` inside `likvido/action-nuget` (`dotnet nuget push -k ...`), **not** the job token. The `GITHUB_TOKEN` is entirely unused.

## Why it's worth doing
`action-nuget` runs `dotnet build -c Release`, which restores from nuget.org and executes third-party MSBuild targets in the same workspace where `actions/checkout` had written a `contents: write` token into `.git/config`. This removes that credential from the workspace and drops the token to read-only.

Matches the implementation already merged in `Likvido.Web`, `Likvido.Robot` and `Likvido.Telemetry` (comment and blocks copied verbatim).
