### PR TITLE
[Likvido.EfCore.MigrationsModel] Let the package own the expand gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,17 @@ Likvido.Whatever.DbMigrator -> Likvido.DbMigrator.EfCore          (which depends
 
 ```csharp
 // The design-time factory - used by the migrator and by `dotnet ef`, and by nothing else.
-var builder = new DbContextOptionsBuilder<ThingContext>()
-    .UseSqlServer(connectionString)
-    .UseMigrationsModel();
+public class ThingDesignTimeDbContextFactory : IDesignTimeDbContextFactory<ThingContext>
+{
+    public ThingContext CreateDbContext(string[] args) =>
+        new(new DbContextOptionsBuilder<ThingContext>()
+            .UseSqlServer(connectionString)
+            .UseMigrationsModel()
+            .Options);
+}
+```
 
+```csharp
 // The context - one class, two models. One call per member that is a release ahead of the code.
 protected override void OnModelCreating(ModelBuilder modelBuilder)
 {
@@ -128,8 +135,10 @@ since a filter simply moved inside a gate would leave the application with no fi
 
 ### Two things that will still cost you a column
 
-- **Every mention of a gated member has to be inside its gate.** `MigrationsOnly` owns the order of the calls
-  it makes, which is why placement in `OnModelCreating` no longer matters; it cannot own calls it never sees.
+- **Every *mapping* of a gated member has to be inside its gate.** `MigrationsOnly` owns the order of the
+  calls it makes, which is why placement in `OnModelCreating` no longer matters; it cannot own calls it never
+  sees. (Ordinary code is a separate question: a gated table's `DbSet` and the navigations pointing at it
+  cannot go inside a gate, which is why they belong to the release that uses the table.)
   An index, key, relationship or `HasData` naming a gated member from outside its gate either does nothing at
   all (if it is above the gate) or puts the member straight back into the application model (if it is below).
   The overload taking a list of members exists so that all of it fits in one call.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ public class ThingDesignTimeDbContextFactory : IDesignTimeDbContextFactory<Thing
 {
     public ThingContext CreateDbContext(string[] args) =>
         new(new DbContextOptionsBuilder<ThingContext>()
-            .UseSqlServer(connectionString)
-            .UseMigrationsModel()
+            .UseSqlServer(connectionString)   // however this repository already resolves it
+            .UseMigrationsModel()             // <- the only line this README is about
             .Options);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ schema for the length of the rollout. The fix is to make every schema change wor
 3. Removals run the cycle backwards: stop using it, deploy, then drop it.
 
 EF6 does this with two contexts, the base one being the migrations model. With one EF Core context, use
-`UseMigrationsModel()` in the design-time factory and gate the ignore on `IsMigrationsModel()`.
+`UseMigrationsModel()` in the design-time factory and `MigrationsOnly(...)` on each member that is a release
+ahead of the code.
 
 Both live in **`Likvido.EfCore.MigrationsModel`**, which depends on nothing but EF Core. Reference it from
 the project that holds the `DbContext` — the gate has to be written there, and that project cannot take
@@ -51,26 +52,59 @@ Likvido.Whatever.DbMigrator -> Likvido.DbMigrator.EfCore          (which depends
 ```
 
 ```csharp
-// The context - one class, two models.
-protected override void OnModelCreating(ModelBuilder modelBuilder)
-{
-    modelBuilder.Entity<Thing>(thing =>
-    {
-        thing.Property(x => x.NewColumn).HasMaxLength(50);
-
-        // The application does not see the column yet. Migrations do.
-        if (!this.IsMigrationsModel())
-        {
-            thing.Ignore(x => x.NewColumn);
-        }
-    });
-}
-
 // The design-time factory - used by the migrator and by `dotnet ef`, and by nothing else.
 var builder = new DbContextOptionsBuilder<ThingContext>()
     .UseSqlServer(connectionString)
     .UseMigrationsModel();
+
+// The context - one class, two models. One call per member that is a release ahead of the code.
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    // A new table.
+    modelBuilder.MigrationsOnly<Gadget>(this, gadget =>
+    {
+        gadget.ToTable("Gadgets");
+        gadget.HasKey(x => x.Id);
+    });
+
+    modelBuilder.Entity<Thing>(thing =>
+    {
+        // A new column.
+        thing.MigrationsOnly(this, x => x.NewColumn, column => column.HasMaxLength(50));
+
+        // A new column that also needs an index, a key or a relationship - anything the property builder
+        // cannot reach. Everything about the gated members goes inside the one call.
+        thing.MigrationsOnly(
+            this,
+            [x => x.CustomerId, x => x.Customer],
+            gated =>
+            {
+                gated.HasOne(x => x.Customer).WithMany().HasForeignKey(x => x.CustomerId);
+                gated.HasIndex(x => x.CustomerId);
+            });
+    });
+}
 ```
+
+The next release replaces each call with the ordinary EF one and needs **no migration**, because the
+migrations model already described the member:
+
+```diff
+-modelBuilder.MigrationsOnly<Gadget>(this, gadget =>
++modelBuilder.Entity<Gadget>(gadget =>
+
+-thing.MigrationsOnly(this, x => x.NewColumn, column => column.HasMaxLength(50));
++thing.Property(x => x.NewColumn).HasMaxLength(50);
+```
+
+A removal runs the same edit backwards: turn the ordinary call into a `MigrationsOnly` one in the release that
+stops using the member, then delete it and generate the drop in the release after. So everything still
+outstanding in a repository is one `grep MigrationsOnly` — nothing here enforces that the second release
+happens, but it is at least countable.
+
+Two things belong in the release that *uses* a gated table, not the one that ships it: its `DbSet` property
+and any navigation pointing at it. A `DbSet` for a gated type throws on first touch; a navigation to it is
+worse, because EF discovers it and quietly puts the whole table back into the application model.
 
 ### The order of the steps does not matter
 
@@ -82,19 +116,60 @@ ways round against a real database.
 migrations model too, so generating a migration after adding one produces an **empty** migration — the change
 you meant to make silently does not exist.
 
-### Three things that will cost you a column
+### Do not write the gate by hand
 
-- **Do not put the `Ignore` above the property's own `Property(...)` call.** The later mapping puts the
-  property back and nothing warns you. Gate it *after* the mapping. The same applies to `Ignore<T>()` for a
-  whole entity: it goes after the `Entity<T>()` block, not before it.
-- **Do not leave the `Ignore` ungated.** An unconditional `Ignore` takes the column out of the migrations
-  model too, so the next migration anyone generates — for something unrelated — diffs a model without the
-  column against a snapshot with it and emits a `DropColumn`.
-- **Do not suppress `PendingModelChangesWarning`.** A gated ignore can no longer put the model and the
+The condition `MigrationsOnly` writes for you used to be written at each call site, and there were three ways
+to write it that compile, read correctly in review, and lose the column: leaving the `Ignore` ungated,
+inverting the condition, and putting the `Ignore` above the mapping it was meant to hide, where the later
+mapping silently undoes it. None of the three is reachable through `MigrationsOnly`. `IsMigrationsModel()`
+stays public for the one thing the gate cannot express — configuration that has to *differ* between the two
+models rather than be absent from one of them, a global query filter over a gated column being the real case,
+since a filter simply moved inside a gate would leave the application with no filter at all.
+
+### Two things that will still cost you a column
+
+- **Every mention of a gated member has to be inside its gate.** `MigrationsOnly` owns the order of the calls
+  it makes, which is why placement in `OnModelCreating` no longer matters; it cannot own calls it never sees.
+  An index, key, relationship or `HasData` naming a gated member from outside its gate either does nothing at
+  all (if it is above the gate) or puts the member straight back into the application model (if it is below).
+  The overload taking a list of members exists so that all of it fits in one call.
+- **Do not suppress `PendingModelChangesWarning`.** A gated member can no longer put the model and the
   snapshot out of step, so it will not fire for that. When it does fire it means a migration is genuinely
   missing, and the answer is to generate it rather than to switch the warning off. It is also the backstop
   if you forget `UseMigrationsModel()`: the migrations model then disagrees with its own snapshot and the
   migrator refuses to run, instead of quietly applying the wrong thing.
+
+### Two warnings worth turning into errors
+
+A model built through `MigrationsOnly` never maps a member before ignoring it, so these two never fire — which
+leaves them free to mean something. Both fire exactly when a gated member was already mapped by configuration
+outside its gate, and both also fire on a gate written by hand:
+
+```csharp
+options.ConfigureWarnings(warnings => warnings.Throw(
+    CoreEventId.MappedPropertyIgnoredWarning,
+    CoreEventId.MappedEntityTypeIgnoredWarning));
+```
+
+Verified on EF Core 10.0.11. It does not catch configuration placed *after* a gate — EF sees a mapping and no
+ignore, so it has no opinion — and what catches that is the first query against a column the migration has not
+created yet.
+
+### The invariant to assert in your own test suite
+
+`MigrationsModelDiagnostics` compares the two models so each repository does not have to:
+
+```csharp
+using var migrations = new ThingDesignTimeDbContextFactory().CreateDbContext([]);
+using var application = new ThingContext(applicationOptions);
+
+MigrationsModelDiagnostics.EntityTypesMissingFromMigrationsModel(migrations, application).ShouldBeEmpty();
+MigrationsModelDiagnostics.PropertiesMissingFromMigrationsModel(migrations, application).ShouldBeEmpty();
+```
+
+A superset rather than an equality, deliberately: it holds whether or not anything is gated, so adopting or
+removing a gate never means editing the test. Pair it with `context.Database.HasPendingModelChanges()` on the
+migrations context, which is the half that catches a member missing from *both* models.
 
 `UseMigrationsModel()` belongs in the design-time factory only. Calling it during application startup gives
 running code columns the database may not have yet, which is the failure the whole pattern exists to avoid.
@@ -102,8 +177,9 @@ running code columns the database may not have yet, which is the failure the who
 A worked cycle for each kind of change — adding a column, adding a table, adding an index, removing either,
 renaming, making a nullable column required — is in NewWiki at
 `developer-workflow/environment-and-setup/DATABASE_MIGRATIONS.md`. Worth knowing before reaching for the
-list: an index needs no gate and ships in one release, because application code never names it, so neither
-deploy order can break.
+list: an index on columns that already exist needs no gate and ships in one release, because application code
+never names it, so neither deploy order can break. An index on a *gated* column is a different thing, and it
+goes inside that column's gate.
 
 ## Run migrations from Package Manager Console
 Since we often have more than one context we should be specific. Default project should be a project that contains the specified context.

--- a/src/Likvido.EfCore.MigrationsModel.Tests/MigrationsModelDiagnosticsTests.cs
+++ b/src/Likvido.EfCore.MigrationsModel.Tests/MigrationsModelDiagnosticsTests.cs
@@ -1,0 +1,101 @@
+using Likvido.EfCore.MigrationsModel;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Likvido.EfCore.MigrationsModel.Tests;
+
+/// <summary>
+/// The invariant every repository using the pattern should assert once: the migrations model is never missing
+/// anything the application model has. What it catches is a gate pointing the wrong way, which
+/// <see cref="MigrationsOnlyExtensions"/> makes unwritable but hand-written gates and any other conditional
+/// mapping do not.
+/// </summary>
+public class MigrationsModelDiagnosticsTests
+{
+    private const string ConnectionString = "Server=localhost;Database=tests;Trusted_Connection=True;";
+
+    private static TContext Build<TContext>(bool migrationsModel, Func<DbContextOptions<TContext>, TContext> create)
+        where TContext : DbContext
+    {
+        var builder = new DbContextOptionsBuilder<TContext>().UseSqlServer(ConnectionString);
+
+        if (migrationsModel)
+        {
+            builder.UseMigrationsModel();
+        }
+
+        return create(builder.Options);
+    }
+
+    [Fact]
+    public void The_diagnostics_name_the_column_an_inverted_gate_hid_from_migrations()
+    {
+        using var migrations = Build<InvertedGateContext>(true, options => new(options));
+        using var application = Build<InvertedGateContext>(false, options => new(options));
+
+        MigrationsModelDiagnostics
+            .PropertiesMissingFromMigrationsModel(migrations, application)
+            .ShouldBe([$"{typeof(Thing).FullName}.{nameof(Thing.NewColumn)}"]);
+    }
+
+    [Fact]
+    public void The_diagnostics_name_the_table_an_inverted_gate_hid_from_migrations()
+    {
+        using var migrations = Build<InvertedTableGateContext>(true, options => new(options));
+        using var application = Build<InvertedTableGateContext>(false, options => new(options));
+
+        MigrationsModelDiagnostics
+            .EntityTypesMissingFromMigrationsModel(migrations, application)
+            .ShouldBe([typeof(Gadget).FullName!]);
+    }
+
+    [Fact]
+    public void The_diagnostics_are_empty_for_a_correctly_gated_context()
+    {
+        // The direction that is meant to happen: the migrations model is the superset.
+        using var migrations = Build<MigrationsOnlyContext>(true, options => new(options));
+        using var application = Build<MigrationsOnlyContext>(false, options => new(options));
+
+        MigrationsModelDiagnostics.EntityTypesMissingFromMigrationsModel(migrations, application).ShouldBeEmpty();
+        MigrationsModelDiagnostics.PropertiesMissingFromMigrationsModel(migrations, application).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Control_the_diagnostics_are_empty_when_nothing_is_gated_at_all()
+    {
+        // Without this the emptiness above could mean the comparison never looks at anything.
+        using var migrations = Build<PlainContext>(true, options => new(options));
+        using var application = Build<PlainContext>(false, options => new(options));
+
+        MigrationsModelDiagnostics.EntityTypesMissingFromMigrationsModel(migrations, application).ShouldBeEmpty();
+        MigrationsModelDiagnostics.PropertiesMissingFromMigrationsModel(migrations, application).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void The_diagnostics_refuse_a_comparison_that_cannot_fail()
+    {
+        // Two contexts built the same way agree about everything, and a test asserting that reads exactly like
+        // a test asserting something. Both mistakes are worth a throw rather than an empty list.
+        using var migrations = Build<InvertedGateContext>(true, options => new(options));
+        using var application = Build<InvertedGateContext>(false, options => new(options));
+
+        Should.Throw<ArgumentException>(
+            () => MigrationsModelDiagnostics.EntityTypesMissingFromMigrationsModel(application, application));
+
+        Should.Throw<ArgumentException>(
+            () => MigrationsModelDiagnostics.PropertiesMissingFromMigrationsModel(migrations, migrations));
+    }
+
+    [Fact]
+    public void The_diagnostics_reject_a_null_subject()
+    {
+        using var context = Build<PlainContext>(true, options => new(options));
+
+        Should.Throw<ArgumentNullException>(
+            () => MigrationsModelDiagnostics.EntityTypesMissingFromMigrationsModel(null!, context));
+
+        Should.Throw<ArgumentNullException>(
+            () => MigrationsModelDiagnostics.PropertiesMissingFromMigrationsModel(context, null!));
+    }
+}

--- a/src/Likvido.EfCore.MigrationsModel.Tests/MigrationsOnlyExtensionsTests.cs
+++ b/src/Likvido.EfCore.MigrationsModel.Tests/MigrationsOnlyExtensionsTests.cs
@@ -1,0 +1,370 @@
+using Likvido.EfCore.MigrationsModel;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Shouldly;
+using Xunit;
+
+namespace Likvido.EfCore.MigrationsModel.Tests;
+
+/// <summary>
+/// The property under test throughout: a <c>MigrationsOnly</c> call maps its member in the migrations model
+/// and hides it from the application model, and does so without the caller having to place it anywhere in
+/// particular. The three mistakes the hand-written gate allows are unwritable here, and the tests near the end
+/// of this file record the two entangled cases that are still possible, because those are what the members
+/// overload exists for.
+/// </summary>
+public class MigrationsOnlyExtensionsTests
+{
+    private const string ConnectionString = "Server=localhost;Database=tests;Trusted_Connection=True;";
+
+    private static TContext Build<TContext>(bool migrationsModel, Func<DbContextOptions<TContext>, TContext> create)
+        where TContext : DbContext
+    {
+        var builder = new DbContextOptionsBuilder<TContext>().UseSqlServer(ConnectionString);
+
+        if (migrationsModel)
+        {
+            builder.UseMigrationsModel();
+        }
+
+        return create(builder.Options);
+    }
+
+    private static bool HasEntityType(DbContext context, Type clrType) =>
+        context.Model.FindEntityType(clrType) is not null;
+
+    private static bool HasProperty(DbContext context, Type clrType, string name) =>
+        context.Model.FindEntityType(clrType)?.FindProperty(name) is not null;
+
+    private static int? MaxLength(DbContext context, Type clrType, string name) =>
+        context.Model.FindEntityType(clrType)!.FindProperty(name)!.GetMaxLength();
+
+    /// <summary>
+    /// Every mapped table, column and column length in one sorted list, so two models can be compared as a
+    /// whole rather than one assertion at a time.
+    /// </summary>
+    private static IReadOnlyList<string> Shape(DbContext context) =>
+        [.. context.Model
+            .GetEntityTypes()
+            .SelectMany(entityType =>
+                entityType
+                    .GetProperties()
+                    .Select(property =>
+                        $"{entityType.Name}[{entityType.GetTableName()}].{property.Name}:{property.GetMaxLength()}"))
+            .Order(StringComparer.Ordinal)];
+
+    // ------------------------------------------------------------------ a gated column
+
+    [Fact]
+    public void The_migrations_model_maps_the_gated_column()
+    {
+        using var context = Build<MigrationsOnlyContext>(true, options => new(options));
+
+        HasProperty(context, typeof(Thing), nameof(Thing.NewColumn)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void The_application_model_does_not_see_the_gated_column()
+    {
+        using var context = Build<MigrationsOnlyContext>(false, options => new(options));
+
+        HasProperty(context, typeof(Thing), nameof(Thing.NewColumn)).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Control_the_ungated_column_beside_it_is_in_both_models(bool migrationsModel)
+    {
+        // Without this, every assertion above would also pass on a model that had lost everything.
+        using var context = Build<MigrationsOnlyContext>(migrationsModel, options => new(options));
+
+        HasProperty(context, typeof(Thing), nameof(Thing.Existing)).ShouldBeTrue();
+    }
+
+    // ------------------------------------------------------------------- a gated table
+
+    [Fact]
+    public void The_migrations_model_maps_the_gated_table()
+    {
+        using var context = Build<MigrationsOnlyContext>(true, options => new(options));
+
+        HasEntityType(context, typeof(Gadget)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void The_application_model_does_not_have_the_gated_table()
+    {
+        using var context = Build<MigrationsOnlyContext>(false, options => new(options));
+
+        HasEntityType(context, typeof(Gadget)).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Control_the_ungated_table_beside_it_is_in_both_models(bool migrationsModel)
+    {
+        using var context = Build<MigrationsOnlyContext>(migrationsModel, options => new(options));
+
+        HasEntityType(context, typeof(Thing)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Touching_the_DbSet_of_a_gated_table_throws()
+    {
+        // The failure the estate shipped: the model builds, and the first read throws. It is the loudest
+        // failure the pattern has, and it is why a gated table is the safer of the two shapes.
+        using var context = Build<GatedTableWithDbSetContext>(false, options => new(options));
+
+        var thrown = Should.Throw<InvalidOperationException>(() => context.Widgets.AsNoTracking().ToQueryString());
+
+        thrown.Message.ShouldContain(nameof(Widget));
+    }
+
+    // --------------------------------------------------------- the configuration delegate
+
+    [Fact]
+    public void The_configuration_delegate_shapes_the_gated_member_in_the_migrations_model()
+    {
+        using var context = Build<MigrationsOnlyContext>(true, options => new(options));
+
+        MaxLength(context, typeof(Thing), nameof(Thing.NewColumn)).ShouldBe(50);
+        MaxLength(context, typeof(Gadget), nameof(Gadget.Name)).ShouldBe(30);
+        context.Model.FindEntityType(typeof(Gadget))!.GetTableName().ShouldBe("Gadgets");
+    }
+
+    [Fact]
+    public void The_configuration_delegate_does_not_run_on_the_application_path()
+    {
+        // Observed through a shadow property the delegate adds rather than a counter: models are cached, so a
+        // counter would carry over between contexts and prove nothing about this one.
+        using var migrations = Build<IndexInsideGateContext>(true, options => new(options));
+        using var application = Build<IndexInsideGateContext>(false, options => new(options));
+
+        HasProperty(migrations, typeof(Thing), IndexInsideGateContext.ConfigureRanMarker).ShouldBeTrue();
+        HasProperty(application, typeof(Thing), IndexInsideGateContext.ConfigureRanMarker).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Omitting_the_configuration_delegate_still_gates_both_shapes(bool migrationsModel)
+    {
+        using var context = Build<MigrationsOnlyWithoutConfigureContext>(migrationsModel, options => new(options));
+
+        HasProperty(context, typeof(Thing), nameof(Thing.NewColumn)).ShouldBe(migrationsModel);
+        HasEntityType(context, typeof(Gadget)).ShouldBe(migrationsModel);
+    }
+
+    // ------------------------------------------------------------- placement no longer matters
+    //
+    // The claim the package is making. Under the hand-written gate, moving the Ignore above the mapping it is
+    // meant to hide silently loses the member - which the two contexts kept in MigrationsModelExtensionsTests
+    // still record. Here the same move is a no-op, because the mapping and the ignore are one call.
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Placement_of_the_gate_does_not_change_either_model(bool migrationsModel)
+    {
+        using var gateLast = Build<MigrationsOnlyContext>(migrationsModel, options => new(options));
+        using var gateFirst = Build<MigrationsOnlyGateFirstContext>(migrationsModel, options => new(options));
+
+        // Same shape, allowing for the two context types naming their entity types identically.
+        Shape(gateFirst).ShouldBe(Shape(gateLast));
+    }
+
+    [Fact]
+    public void The_migrations_model_is_identical_to_the_model_release_two_builds()
+    {
+        // Why release two needs no migration: the gates were the only difference, and they never touched the
+        // migrations model. If this fails, the configuration delegate is being applied differently from the
+        // ordinary call and release two would generate a migration nobody expects.
+        using var migrations = Build<MigrationsOnlyContext>(true, options => new(options));
+        using var releaseTwo = Build<ReleaseTwoContext>(false, options => new(options));
+
+        Shape(releaseTwo).ShouldBe(Shape(migrations));
+    }
+
+    // ---------------------------------------------------------------- EF's own diagnostics
+
+    [Fact]
+    public void The_gate_does_not_report_that_a_mapped_member_was_ignored()
+    {
+        // Nothing is mapped on the application path, so there is nothing for EF to complain about. The
+        // hand-written idiom maps and then ignores, which is what the control below shows.
+        using var context = MappedThenIgnoredIsAnError<MigrationsOnlyContext>(options => new(options));
+
+        Should.NotThrow(() => context.Model);
+    }
+
+    [Fact]
+    public void Control_the_hand_written_gate_does_report_that_a_mapped_member_was_ignored()
+    {
+        using var context = MappedThenIgnoredIsAnError<GatedContext>(options => new(options));
+
+        Should.Throw<InvalidOperationException>(() => context.Model);
+    }
+
+    private static TContext MappedThenIgnoredIsAnError<TContext>(Func<DbContextOptions<TContext>, TContext> create)
+        where TContext : DbContext =>
+        create(
+            new DbContextOptionsBuilder<TContext>()
+                .UseSqlServer(ConnectionString)
+                .ConfigureWarnings(warnings => warnings.Throw(
+                    CoreEventId.MappedPropertyIgnoredWarning,
+                    CoreEventId.MappedEntityTypeIgnoredWarning))
+                .Options);
+
+    // ------------------------------------------------------- what a gate still cannot own
+    //
+    // These record EF behaviour rather than this package's. Both are the same rule seen twice: an explicit
+    // mapping of a gated member from outside the gate un-ignores it, and the gate cannot see calls it did not
+    // make. They are the reason the overload taking a list of members exists.
+
+    [Fact]
+    public void An_index_declared_after_the_gate_puts_the_column_back()
+    {
+        using var context = Build<IndexAfterGateContext>(false, options => new(options));
+
+        // HasIndex maps the property to reach it, and that mapping overrides the ignore. Nothing warns.
+        HasProperty(context, typeof(Thing), nameof(Thing.NewColumn)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void An_index_declared_inside_the_gate_stays_out_of_the_application_model()
+    {
+        using var migrations = Build<IndexInsideGateContext>(true, options => new(options));
+        using var application = Build<IndexInsideGateContext>(false, options => new(options));
+
+        HasProperty(migrations, typeof(Thing), nameof(Thing.NewColumn)).ShouldBeTrue();
+        migrations.Model.FindEntityType(typeof(Thing))!.GetIndexes().ShouldNotBeEmpty();
+
+        HasProperty(application, typeof(Thing), nameof(Thing.NewColumn)).ShouldBeFalse();
+        application.Model.FindEntityType(typeof(Thing))!.GetIndexes().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Gating_a_column_the_rest_of_the_model_already_mapped_does_nothing_at_all()
+    {
+        // ⚠️ Verified on EF Core 10.0.11. The relationship above the gate maps CustomerId explicitly, and an
+        // explicit mapping cannot be removed by ignoring it afterwards while a foreign key is still using it -
+        // so the gate is a no-op and the application model keeps the column, the foreign key and the
+        // navigation. The member is not renamed, shadowed or half-removed; nothing happens.
+        using var context = Build<ForeignKeyBeforeGateContext>(false, options => new(options));
+
+        var order = context.Model.FindEntityType(typeof(Order))!;
+        var property = order.FindProperty(nameof(Order.CustomerId)).ShouldNotBeNull();
+
+        property.IsShadowProperty().ShouldBeFalse();
+        order.GetForeignKeys().ShouldHaveSingleItem().Properties.ShouldHaveSingleItem().ShouldBe(property);
+        order.FindNavigation(nameof(Order.Customer)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void EF_reports_the_gate_that_did_nothing_as_a_mapped_member_that_was_ignored()
+    {
+        // The reason the warning escalation is worth switching on in an application: this is the one entangled
+        // shape the gate cannot detect for itself, and EF names the exact member.
+        using var context = MappedThenIgnoredIsAnError<ForeignKeyBeforeGateContext>(options => new(options));
+
+        var thrown = Should.Throw<InvalidOperationException>(() => context.Model);
+
+        thrown.Message.ShouldContain(nameof(Order.CustomerId));
+    }
+
+    [Fact]
+    public void Nothing_reports_the_index_that_put_the_column_back()
+    {
+        // ⚠️ The mirror image, and the residual hole: configuration that maps a gated member AFTER the gate is
+        // silent even with every ignore-related warning escalated, because from EF's point of view nothing was
+        // ignored and then mapped - it was mapped, full stop. What catches it is the database: the application
+        // queries a column the migration has not created yet.
+        using var context = MappedThenIgnoredIsAnError<IndexAfterGateContext>(options => new(options));
+
+        Should.NotThrow(() => context.Model);
+        HasProperty(context, typeof(Thing), nameof(Thing.NewColumn)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Gating_a_foreign_key_together_with_its_navigation_removes_the_whole_relationship()
+    {
+        using var migrations = Build<GatedForeignKeyContext>(true, options => new(options));
+        using var application = Build<GatedForeignKeyContext>(false, options => new(options));
+
+        HasProperty(migrations, typeof(Order), nameof(Order.CustomerId)).ShouldBeTrue();
+        migrations.Model.FindEntityType(typeof(Order))!.GetForeignKeys().ShouldNotBeEmpty();
+
+        HasProperty(application, typeof(Order), nameof(Order.CustomerId)).ShouldBeFalse();
+        application.Model.FindEntityType(typeof(Order))!.FindNavigation(nameof(Order.Customer)).ShouldBeNull();
+        application.Model.FindEntityType(typeof(Order))!.GetForeignKeys().ShouldBeEmpty();
+    }
+
+    // ------------------------------------------------------------------- argument guards
+
+    [Fact]
+    public void The_table_gate_rejects_a_null_builder_and_a_null_subject()
+    {
+        using var context = Build<MigrationsOnlyContext>(false, options => new(options));
+        var modelBuilder = new ModelBuilder();
+
+        Should.Throw<ArgumentNullException>(() => ((ModelBuilder)null!).MigrationsOnly<Gadget>(context));
+        Should.Throw<ArgumentNullException>(() => modelBuilder.MigrationsOnly<Gadget>((DbContext)null!));
+        Should.Throw<ArgumentNullException>(() => modelBuilder.MigrationsOnly<Gadget>((DbContextOptions)null!));
+    }
+
+    [Fact]
+    public void The_column_gate_rejects_a_null_builder_and_a_null_subject()
+    {
+        using var context = Build<MigrationsOnlyContext>(false, options => new(options));
+        var thing = new ModelBuilder().Entity<Thing>();
+
+        Should.Throw<ArgumentNullException>(
+            () => ((EntityTypeBuilder<Thing>)null!).MigrationsOnly(context, entity => entity.NewColumn));
+        Should.Throw<ArgumentNullException>(
+            () => thing.MigrationsOnly((DbContext)null!, entity => entity.NewColumn));
+        Should.Throw<ArgumentNullException>(
+            () => thing.MigrationsOnly((DbContextOptions)null!, entity => entity.NewColumn));
+        Should.Throw<ArgumentNullException>(
+            () => thing.MigrationsOnly<Thing, string?>(context, null!));
+    }
+
+    [Fact]
+    public void The_members_gate_rejects_an_empty_list()
+    {
+        using var context = Build<MigrationsOnlyContext>(false, options => new(options));
+        var thing = new ModelBuilder().Entity<Thing>();
+
+        // A call that gates nothing is a call that only configures the migrations model, which is the
+        // divergence this package exists to prevent rather than to offer.
+        Should.Throw<ArgumentException>(() => thing.MigrationsOnly(context, []));
+    }
+
+    [Fact]
+    public void A_gate_rejects_an_expression_that_is_not_a_plain_member_access()
+    {
+        using var context = Build<MigrationsOnlyContext>(false, options => new(options));
+        var thing = new ModelBuilder().Entity<Thing>();
+
+        Should.Throw<ArgumentException>(
+            () => thing.MigrationsOnly(context, entity => entity.Existing!.Length));
+    }
+
+    [Fact]
+    public void Passing_a_navigation_to_the_column_gate_is_rejected()
+    {
+        // It would otherwise map on one path and ignore on the other - a difference between the two models
+        // produced by the gate itself, which is the one thing the gate must never do.
+        using var context = Build<GatedForeignKeyContext>(false, options => new(options));
+
+        var order = new ModelBuilder().Entity<Order>();
+        order.HasOne(entity => entity.Customer).WithMany().HasForeignKey(entity => entity.CustomerId);
+
+        var thrown = Should.Throw<ArgumentException>(
+            () => order.MigrationsOnly(context, entity => entity.Customer));
+
+        thrown.Message.ShouldContain(nameof(Order.Customer));
+    }
+}

--- a/src/Likvido.EfCore.MigrationsModel.Tests/TestContexts.cs
+++ b/src/Likvido.EfCore.MigrationsModel.Tests/TestContexts.cs
@@ -261,9 +261,10 @@ public class IndexInsideGateContext(DbContextOptions<IndexInsideGateContext> opt
 }
 
 /// <summary>
-/// ⚠️ A gated foreign key with the relationship configured outside the gate, above it. The ignore removes the
-/// CLR property, and EF then rebuilds the relationship over a shadow property with a uniquified name - so the
-/// application model does not lose the column, it renames it to one the database does not have.
+/// ⚠️ A gated foreign key with the relationship configured outside the gate, above it. The relationship has
+/// already mapped CustomerId explicitly, and an explicit mapping cannot be removed by ignoring it afterwards
+/// while a foreign key is still using it - so the gate does nothing at all, and the application model keeps
+/// the column, the foreign key and the navigation. EF reports it as MappedPropertyIgnoredWarning.
 /// </summary>
 public class ForeignKeyBeforeGateContext(DbContextOptions<ForeignKeyBeforeGateContext> options) : DbContext(options)
 {

--- a/src/Likvido.EfCore.MigrationsModel.Tests/TestContexts.cs
+++ b/src/Likvido.EfCore.MigrationsModel.Tests/TestContexts.cs
@@ -13,8 +13,10 @@ public class Thing
 }
 
 /// <summary>
-/// The idiom this package exists to support: one context, the expand/contract ignore gated on the
-/// migration path, and the gate placed after the property's own mapping.
+/// The gate written by hand, which <c>MigrationsOnly</c> now writes instead: the ignore gated on the migration
+/// path, placed after the property's own mapping because above it would be silently undone. Kept because it is
+/// the control for the two tests that show what the package's version does differently - it maps the property
+/// on both paths, which is what makes EF report <c>MappedPropertyIgnoredWarning</c>.
 /// </summary>
 public class GatedContext(DbContextOptions<GatedContext> options) : DbContext(options)
 {
@@ -38,8 +40,9 @@ public class GatedContext(DbContextOptions<GatedContext> options) : DbContext(op
 }
 
 /// <summary>
-/// What the estate does today: an ungated ignore. Present so the test suite states what is wrong with it
-/// rather than only describing it in a comment.
+/// An ungated ignore - the first of the three mistakes the hand-written gate allows, and unwritable through
+/// <c>MigrationsOnly</c>. Present so the test suite states what is wrong with it rather than only describing it
+/// in a comment.
 /// </summary>
 public class UngatedContext(DbContextOptions<UngatedContext> options) : DbContext(options)
 {
@@ -57,7 +60,8 @@ public class UngatedContext(DbContextOptions<UngatedContext> options) : DbContex
 }
 
 /// <summary>
-/// The ordering footgun: the ignore sits above the property's own mapping, which silently undoes it.
+/// The ordering footgun: the ignore sits above the property's own mapping, which silently undoes it. Compare
+/// <see cref="MigrationsOnlyGateFirstContext"/>, where the same move is a no-op.
 /// </summary>
 public class IgnoreBeforeMappingContext(DbContextOptions<IgnoreBeforeMappingContext> options) : DbContext(options)
 {
@@ -71,5 +75,287 @@ public class IgnoreBeforeMappingContext(DbContextOptions<IgnoreBeforeMappingCont
             thing.Ignore(x => x.NewColumn);
             thing.Property(x => x.NewColumn).HasMaxLength(50);
         });
+    }
+}
+
+/// <summary>A table mid-cycle: in the database, not yet read by application code.</summary>
+public class Gadget
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+}
+
+/// <summary>A gated table that a context also declares a <c>DbSet</c> for, which is a release too early.</summary>
+public class Widget
+{
+    public int Id { get; set; }
+}
+
+public class Customer
+{
+    public int Id { get; set; }
+}
+
+/// <summary>Carries a gated foreign key, which is the entangled case the single-property gate cannot hold.</summary>
+public class Order
+{
+    public int Id { get; set; }
+    public int? CustomerId { get; set; }
+    public Customer? Customer { get; set; }
+}
+
+/// <summary>
+/// The idiom the package provides, with every gate as the <em>last</em> statement of its block - the placement
+/// the hand-written form requires. <see cref="MigrationsOnlyGateFirstContext"/> is the same model with every
+/// gate first, and the pair is what proves placement no longer matters.
+/// </summary>
+public class MigrationsOnlyContext(DbContextOptions<MigrationsOnlyContext> options) : DbContext(options)
+{
+    public DbSet<Thing> Things => Set<Thing>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Thing>(thing =>
+        {
+            thing.HasKey(entity => entity.Id);
+            thing.Property(entity => entity.Existing).HasMaxLength(50);
+            thing.MigrationsOnly(this, entity => entity.NewColumn, column => column.HasMaxLength(50));
+        });
+
+        modelBuilder.MigrationsOnly<Gadget>(this, gadget =>
+        {
+            gadget.ToTable("Gadgets");
+            gadget.HasKey(entity => entity.Id);
+            gadget.Property(entity => entity.Name).HasMaxLength(30);
+        });
+    }
+}
+
+/// <summary>
+/// <see cref="MigrationsOnlyContext"/>'s model, with both gates moved to the front of their blocks. Under the
+/// hand-written idiom this ordering silently loses the column - see <see cref="IgnoreBeforeMappingContext"/>.
+/// </summary>
+public class MigrationsOnlyGateFirstContext(DbContextOptions<MigrationsOnlyGateFirstContext> options)
+    : DbContext(options)
+{
+    public DbSet<Thing> Things => Set<Thing>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.MigrationsOnly<Gadget>(this, gadget =>
+        {
+            gadget.ToTable("Gadgets");
+            gadget.HasKey(entity => entity.Id);
+            gadget.Property(entity => entity.Name).HasMaxLength(30);
+        });
+
+        modelBuilder.Entity<Thing>(thing =>
+        {
+            thing.MigrationsOnly(this, entity => entity.NewColumn, column => column.HasMaxLength(50));
+            thing.HasKey(entity => entity.Id);
+            thing.Property(entity => entity.Existing).HasMaxLength(50);
+        });
+    }
+}
+
+/// <summary>
+/// <see cref="MigrationsOnlyContext"/>'s model as the <em>next</em> release writes it: the gates replaced by
+/// the ordinary EF calls. Its model is what the migrations model has to already equal, because that equality
+/// is what makes release two need no migration.
+/// </summary>
+public class ReleaseTwoContext(DbContextOptions<ReleaseTwoContext> options) : DbContext(options)
+{
+    public DbSet<Thing> Things => Set<Thing>();
+    public DbSet<Gadget> Gadgets => Set<Gadget>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Thing>(thing =>
+        {
+            thing.HasKey(entity => entity.Id);
+            thing.Property(entity => entity.Existing).HasMaxLength(50);
+            thing.Property(entity => entity.NewColumn).HasMaxLength(50);
+        });
+
+        modelBuilder.Entity<Gadget>(gadget =>
+        {
+            gadget.ToTable("Gadgets");
+            gadget.HasKey(entity => entity.Id);
+            gadget.Property(entity => entity.Name).HasMaxLength(30);
+        });
+    }
+}
+
+/// <summary>Neither gate is given a configuration delegate, so EF's conventions map both.</summary>
+public class MigrationsOnlyWithoutConfigureContext(DbContextOptions<MigrationsOnlyWithoutConfigureContext> options)
+    : DbContext(options)
+{
+    public DbSet<Thing> Things => Set<Thing>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Thing>(thing =>
+        {
+            thing.HasKey(entity => entity.Id);
+            thing.MigrationsOnly(this, entity => entity.NewColumn);
+        });
+
+        modelBuilder.MigrationsOnly<Gadget>(this);
+    }
+}
+
+/// <summary>
+/// A gated table with a <c>DbSet</c> declared for it, which is the shape the estate shipped by accident: the
+/// model builds, and the first touch of the set throws.
+/// </summary>
+public class GatedTableWithDbSetContext(DbContextOptions<GatedTableWithDbSetContext> options) : DbContext(options)
+{
+    public DbSet<Widget> Widgets => Set<Widget>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.MigrationsOnly<Widget>(this, widget => widget.HasKey(entity => entity.Id));
+}
+
+/// <summary>
+/// ⚠️ An index on the gated column, declared outside the gate and after it. The index's own call maps the
+/// property again, which un-ignores it, so the application model gets both the column and the index. This
+/// records EF's behaviour, and it is the reason the members overload exists.
+/// </summary>
+public class IndexAfterGateContext(DbContextOptions<IndexAfterGateContext> options) : DbContext(options)
+{
+    public DbSet<Thing> Things => Set<Thing>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.Entity<Thing>(thing =>
+        {
+            thing.HasKey(entity => entity.Id);
+            thing.MigrationsOnly(this, entity => entity.NewColumn, column => column.HasMaxLength(50));
+            thing.HasIndex(entity => entity.NewColumn);
+        });
+}
+
+/// <summary>
+/// The same index, inside the gate. The delegate also adds a shadow property, which is how the tests observe
+/// whether it ran at all without relying on a counter - models are cached, so a counter would be sticky.
+/// </summary>
+public class IndexInsideGateContext(DbContextOptions<IndexInsideGateContext> options) : DbContext(options)
+{
+    public const string ConfigureRanMarker = "ConfigureRan";
+
+    public DbSet<Thing> Things => Set<Thing>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.Entity<Thing>(thing =>
+        {
+            thing.HasKey(entity => entity.Id);
+            thing.MigrationsOnly(
+                this,
+                [entity => entity.NewColumn],
+                gated =>
+                {
+                    gated.Property(entity => entity.NewColumn).HasMaxLength(50);
+                    gated.HasIndex(entity => entity.NewColumn);
+                    gated.Property<string>(ConfigureRanMarker);
+                });
+        });
+}
+
+/// <summary>
+/// ⚠️ A gated foreign key with the relationship configured outside the gate, above it. The ignore removes the
+/// CLR property, and EF then rebuilds the relationship over a shadow property with a uniquified name - so the
+/// application model does not lose the column, it renames it to one the database does not have.
+/// </summary>
+public class ForeignKeyBeforeGateContext(DbContextOptions<ForeignKeyBeforeGateContext> options) : DbContext(options)
+{
+    public DbSet<Order> Orders => Set<Order>();
+    public DbSet<Customer> Customers => Set<Customer>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Customer>(customer => customer.HasKey(entity => entity.Id));
+
+        modelBuilder.Entity<Order>(order =>
+        {
+            order.HasKey(entity => entity.Id);
+            order.HasOne(entity => entity.Customer).WithMany().HasForeignKey(entity => entity.CustomerId);
+            order.MigrationsOnly(this, entity => entity.CustomerId);
+        });
+    }
+}
+
+/// <summary>
+/// The same foreign key done properly: the column, the navigation and the relationship all inside one gate.
+/// </summary>
+public class GatedForeignKeyContext(DbContextOptions<GatedForeignKeyContext> options) : DbContext(options)
+{
+    public DbSet<Order> Orders => Set<Order>();
+    public DbSet<Customer> Customers => Set<Customer>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Customer>(customer => customer.HasKey(entity => entity.Id));
+
+        modelBuilder.Entity<Order>(order =>
+        {
+            order.HasKey(entity => entity.Id);
+            order.MigrationsOnly(
+                this,
+                [entity => entity.CustomerId, entity => entity.Customer],
+                gated => gated
+                    .HasOne(entity => entity.Customer)
+                    .WithMany()
+                    .HasForeignKey(entity => entity.CustomerId));
+        });
+    }
+}
+
+/// <summary>
+/// The gate written the wrong way round by hand, which is what <see cref="MigrationsModelDiagnostics"/>
+/// exists to catch: the migrations model is the one missing the column.
+/// </summary>
+public class InvertedGateContext(DbContextOptions<InvertedGateContext> options) : DbContext(options)
+{
+    public DbSet<Thing> Things => Set<Thing>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.Entity<Thing>(thing =>
+        {
+            thing.HasKey(entity => entity.Id);
+            thing.Property(entity => entity.NewColumn).HasMaxLength(50);
+
+            // ⚠️ Missing the `!`. Compiles, reads almost the same, leaves migrations blind to the column.
+            if (this.IsMigrationsModel())
+            {
+                thing.Ignore(entity => entity.NewColumn);
+            }
+        });
+}
+
+/// <summary>Nothing gated at all - the control that stops the diagnostics tests being vacuous.</summary>
+public class PlainContext(DbContextOptions<PlainContext> options) : DbContext(options)
+{
+    public DbSet<Thing> Things => Set<Thing>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.Entity<Thing>(thing => thing.HasKey(entity => entity.Id));
+}
+
+/// <summary>
+/// The entity-level twin of <see cref="InvertedGateContext"/>: the table is in the application model and
+/// missing from migrations, so the next migration generated drops a table the application queries.
+/// </summary>
+public class InvertedTableGateContext(DbContextOptions<InvertedTableGateContext> options) : DbContext(options)
+{
+    public DbSet<Gadget> Gadgets => Set<Gadget>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Gadget>(gadget => gadget.HasKey(entity => entity.Id));
+
+        // ⚠️ Missing the `!`, on a whole table this time.
+        if (this.IsMigrationsModel())
+        {
+            modelBuilder.Ignore<Gadget>();
+        }
     }
 }

--- a/src/Likvido.EfCore.MigrationsModel/MigrationsModelDiagnostics.cs
+++ b/src/Likvido.EfCore.MigrationsModel/MigrationsModelDiagnostics.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+
+namespace Likvido.EfCore.MigrationsModel;
+
+/// <summary>
+/// The one invariant a repository using expand/contract should assert in its own test suite: <strong>the
+/// migrations model is never missing anything the application model has.</strong>
+/// <para>
+/// A superset rather than an equality, deliberately. It holds whether or not anything is gated at the moment,
+/// so adopting or removing a gate never means editing the test — and what it catches is the gate pointing the
+/// wrong way, <c>if (this.IsMigrationsModel())</c> written without the <c>!</c>, which leaves migrations blind
+/// to a member the application is writing to. <see cref="MigrationsOnlyExtensions"/> makes that particular
+/// mistake unreachable, so this is the guard for the hand-written gates that predate it and for anything else
+/// that ends up conditioning a mapping.
+/// </para>
+/// <para>
+/// It lives here rather than in each repository's test project because the hand-written version is easy to
+/// write too narrowly — comparing the properties of one entity type and reading as though it compared them
+/// all.
+/// </para>
+/// <example>
+/// <code>
+/// [Fact]
+/// public void The_migrations_model_is_never_missing_what_the_application_model_has()
+/// {
+///     using var migrations = new ThingDesignTimeDbContextFactory().CreateDbContext([]);
+///     using var application = ApplicationContext();
+///
+///     MigrationsModelDiagnostics.EntityTypesMissingFromMigrationsModel(migrations, application).ShouldBeEmpty();
+///     MigrationsModelDiagnostics.PropertiesMissingFromMigrationsModel(migrations, application).ShouldBeEmpty();
+/// }
+/// </code>
+/// </example>
+/// <para>
+/// The other half of the pattern's coverage is <c>context.Database.HasPendingModelChanges()</c> on the
+/// migrations context, which is what catches an ungated ignore — both models lose the member together, so no
+/// comparison between them can see it, but the model snapshot still has it. That one needs nothing from this
+/// package.
+/// </para>
+/// </summary>
+public static class MigrationsModelDiagnostics
+{
+    /// <summary>
+    /// Entity types the application model maps and the migrations model does not, by EF model name, sorted.
+    /// Empty is the healthy answer.
+    /// </summary>
+    /// <param name="migrationsModel">
+    /// A context built through the design-time factory, so with <c>UseMigrationsModel()</c> applied.
+    /// </param>
+    /// <param name="applicationModel">
+    /// A context built the way the application builds it — provider and connection string, nothing else.
+    /// </param>
+    public static IReadOnlyList<string> EntityTypesMissingFromMigrationsModel(
+        DbContext migrationsModel,
+        DbContext applicationModel)
+    {
+        RejectVacuousComparison(migrationsModel, applicationModel);
+
+        var mapped = EntityTypeNames(migrationsModel);
+
+        return [.. EntityTypeNames(applicationModel).Where(name => !mapped.Contains(name)).Order(StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// Properties the application model maps and the migrations model does not, as
+    /// <c>EntityType.Property</c>, sorted. Empty is the healthy answer.
+    /// <para>
+    /// Entity types missing from the migrations model altogether are left to
+    /// <see cref="EntityTypesMissingFromMigrationsModel"/> rather than reported once per property here.
+    /// Navigations are not compared: a navigation is not something the expand gate hides.
+    /// </para>
+    /// </summary>
+    /// <param name="migrationsModel">
+    /// A context built through the design-time factory, so with <c>UseMigrationsModel()</c> applied.
+    /// </param>
+    /// <param name="applicationModel">
+    /// A context built the way the application builds it — provider and connection string, nothing else.
+    /// </param>
+    public static IReadOnlyList<string> PropertiesMissingFromMigrationsModel(
+        DbContext migrationsModel,
+        DbContext applicationModel)
+    {
+        RejectVacuousComparison(migrationsModel, applicationModel);
+
+        var missing = new List<string>();
+
+        foreach (var applicationEntityType in applicationModel.Model.GetEntityTypes())
+        {
+            var migrationsEntityType = migrationsModel.Model.FindEntityType(applicationEntityType.Name);
+
+            if (migrationsEntityType is null)
+            {
+                continue;
+            }
+
+            missing.AddRange(
+                applicationEntityType
+                    .GetProperties()
+                    .Where(property => migrationsEntityType.FindProperty(property.Name) is null)
+                    .Select(property => $"{applicationEntityType.Name}.{property.Name}"));
+        }
+
+        return [.. missing.Order(StringComparer.Ordinal)];
+    }
+
+    private static HashSet<string> EntityTypeNames(DbContext context) =>
+        [.. context.Model.GetEntityTypes().Select(entityType => entityType.Name)];
+
+    /// <summary>
+    /// ⚠️ <strong>Two contexts built the same way agree about everything, and a test asserting that reads
+    /// exactly like a test asserting something.</strong> The comparison only means anything with one context
+    /// from each side, so the arguments being swapped or duplicated is worth a throw rather than an empty
+    /// list.
+    /// </summary>
+    private static void RejectVacuousComparison(DbContext migrationsModel, DbContext applicationModel)
+    {
+        ArgumentNullException.ThrowIfNull(migrationsModel);
+        ArgumentNullException.ThrowIfNull(applicationModel);
+
+        if (!migrationsModel.IsMigrationsModel())
+        {
+            throw new ArgumentException(
+                "This context was not built with UseMigrationsModel(), so it is not the migrations model. "
+                + "Build it through the design-time factory, which is the only place that opt-in belongs.",
+                nameof(migrationsModel));
+        }
+
+        if (applicationModel.IsMigrationsModel())
+        {
+            throw new ArgumentException(
+                "This context was built with UseMigrationsModel(), so it is the migrations model rather than "
+                + "the application model. Comparing the migrations model against itself can only pass.",
+                nameof(applicationModel));
+        }
+    }
+}

--- a/src/Likvido.EfCore.MigrationsModel/MigrationsModelExtensions.cs
+++ b/src/Likvido.EfCore.MigrationsModel/MigrationsModelExtensions.cs
@@ -24,29 +24,29 @@ namespace Likvido.EfCore.MigrationsModel;
 /// a migration somebody forgot to generate.
 /// </para>
 /// <example>
-/// In the context, with the ignore gated:
-/// <code>
-/// protected override void OnModelCreating(ModelBuilder modelBuilder)
-/// {
-///     modelBuilder.Entity&lt;Thing&gt;(thing =>
-///     {
-///         thing.Property(x => x.NewColumn).HasMaxLength(50);
-///
-///         // ⚠️ AFTER the property's own mapping, never before it.
-///         if (!this.IsMigrationsModel())
-///         {
-///             thing.Ignore(x => x.NewColumn);
-///         }
-///     });
-/// }
-/// </code>
 /// In the design-time factory, which only the migrator and <c>dotnet ef</c> ever use:
 /// <code>
 /// var builder = new DbContextOptionsBuilder&lt;ThingContext&gt;()
 ///     .UseSqlServer(connectionString)
 ///     .UseMigrationsModel();
 /// </code>
+/// In the context, one call per gated member:
+/// <code>
+/// protected override void OnModelCreating(ModelBuilder modelBuilder)
+/// {
+///     modelBuilder.Entity&lt;Thing&gt;(thing =>
+///     {
+///         thing.MigrationsOnly(this, x => x.NewColumn, column => column.HasMaxLength(50));
+///     });
+/// }
+/// </code>
 /// </example>
+/// <para>
+/// <see cref="MigrationsOnlyExtensions"/> is what a caller writes. The condition it replaces is still public
+/// and still supported, for the one thing the gate cannot express — configuration that has to <em>differ</em>
+/// between the two models rather than be absent from one of them — but a gate written by hand has three ways
+/// to go wrong that a <c>MigrationsOnly</c> call does not.
+/// </para>
 /// </summary>
 public static class MigrationsModelExtensions
 {
@@ -81,8 +81,14 @@ public static class MigrationsModelExtensions
     }
 
     /// <summary>
-    /// True while this context is building the migrations model. Gate every expand/contract
-    /// <c>Ignore</c> on it, and place the gate after the property's own mapping.
+    /// True while this context is building the migrations model.
+    /// <para>
+    /// Prefer <see cref="MigrationsOnlyExtensions"/> for hiding a table or column from the application model:
+    /// it writes this condition for you, in the one order that works. Read the flag directly for configuration
+    /// that has to <em>differ</em> between the two models — a global query filter over a gated column is the
+    /// real example, because a filter simply moved inside a gate would leave the application with no filter at
+    /// all.
+    /// </para>
     /// <para>
     /// Safe to call from inside <c>OnModelCreating</c>, which is the only place it is meant to be called.
     /// </para>

--- a/src/Likvido.EfCore.MigrationsModel/MigrationsOnlyExtensions.cs
+++ b/src/Likvido.EfCore.MigrationsModel/MigrationsOnlyExtensions.cs
@@ -1,0 +1,410 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Likvido.EfCore.MigrationsModel;
+
+/// <summary>
+/// The expand half of expand/contract, as one call: a table or column that the migrations model maps and the
+/// application model does not know exists.
+/// <para>
+/// <strong>Why the package owns this rather than documenting it.</strong> The same thing can be written by
+/// hand as an <c>Ignore</c> inside <c>if (!this.IsMigrationsModel())</c>, and there are three ways to write
+/// that which compile, read correctly in review, and lose the column: leaving the <c>Ignore</c> ungated,
+/// inverting the condition, and placing the <c>Ignore</c> above the mapping it is meant to hide — where the
+/// later mapping silently puts the member back. None of the three is reachable through these methods, because
+/// the mapping and the ignore are the same call and the call decides the order.
+/// </para>
+/// <example>
+/// A new table, and a new column on an existing one:
+/// <code>
+/// protected override void OnModelCreating(ModelBuilder modelBuilder)
+/// {
+///     modelBuilder.MigrationsOnly&lt;Gadget&gt;(this, gadget =&gt;
+///     {
+///         gadget.ToTable("Gadgets");
+///         gadget.HasKey(entity =&gt; entity.Id);
+///     });
+///
+///     modelBuilder.Entity&lt;Thing&gt;(thing =&gt;
+///     {
+///         thing.HasKey(entity =&gt; entity.Id);
+///         thing.MigrationsOnly(this, entity =&gt; entity.NewColumn, column =&gt; column.HasMaxLength(50));
+///     });
+/// }
+/// </code>
+/// The next release replaces each call with the ordinary EF one — <c>Entity&lt;Gadget&gt;(gadget =&gt; …)</c>
+/// and <c>thing.Property(entity =&gt; entity.NewColumn).HasMaxLength(50)</c> — and needs no migration, because
+/// the migrations model already described both. A removal runs the same edit backwards: turn the ordinary call
+/// into a <c>MigrationsOnly</c> one in the release that stops using the member, then delete it and generate
+/// the drop in the release after. Everything still outstanding in a repository is therefore one grep for
+/// <c>MigrationsOnly</c>. Nothing here enforces that the second release happens — that remains something to
+/// remember — but it is at least countable.
+/// </example>
+/// <para>
+/// ⚠️ <strong>What placement-independence actually buys, stated precisely.</strong> These methods make the
+/// order of the calls they make irrelevant, which is why the <c>Ignore</c>-above-the-mapping mistake cannot be
+/// written. They cannot own the order of calls they never see: <em>every</em> mention of a gated member — its
+/// facets, its index, its key, its relationship, its seed data — has to be inside a gated call. An explicit
+/// mapping of a gated member anywhere else puts it straight back into the application model, and silently,
+/// because EF treats a later explicit mapping as un-ignoring the member. The overload taking a list of members
+/// exists so that the awkward cases — an index on a gated column, a foreign key and its navigation — have
+/// somewhere to go.
+/// </para>
+/// <para>
+/// <strong>Switch the two ignore warnings into errors and the one blind spot closes.</strong> A healthy
+/// application model built through these methods maps nothing before ignoring it, so
+/// <c>MappedPropertyIgnoredWarning</c> and <c>MappedEntityTypeIgnoredWarning</c> never fire — which leaves
+/// them free to mean something. Both fire exactly when a gated member was already mapped by configuration
+/// outside its gate, the case above that the gate cannot see, and both also fire on a gate written by hand,
+/// which maps and then ignores:
+/// <code>
+/// options.ConfigureWarnings(warnings =&gt; warnings.Throw(
+///     CoreEventId.MappedPropertyIgnoredWarning,
+///     CoreEventId.MappedEntityTypeIgnoredWarning));
+/// </code>
+/// Verified on EF Core 10.0.11. It does not catch configuration placed <em>after</em> a gate, which maps the
+/// member without ignoring anything and so is not a shape EF has an opinion about; what catches that is the
+/// first query against a column the migration has not created yet.
+/// </para>
+/// <para>
+/// Configuration that has to <em>differ</em> between the two models rather than be absent from one of them — a
+/// global query filter over a gated column is the real example — is not something these methods express.
+/// <see cref="MigrationsModelExtensions.IsMigrationsModel(DbContext)"/> stays public for exactly that, and a
+/// filter simply moved inside a gate would leave the application with no filter at all.
+/// </para>
+/// </summary>
+public static class MigrationsOnlyExtensions
+{
+    /// <summary>
+    /// Maps <typeparamref name="TEntity"/> in the migrations model and hides it from the application model,
+    /// for a table being shipped a release ahead of the code that reads it.
+    /// <para>
+    /// <paramref name="configure"/> runs on the migration path only. The application path has no mapped
+    /// entity type to configure, and mapping it there in order to ignore it again is both pointless and the
+    /// shape EF reports as <c>MappedEntityTypeIgnoredWarning</c>.
+    /// </para>
+    /// <para>
+    /// ⚠️ <strong>Nothing outside <paramref name="configure"/> may name the gated type.</strong> A
+    /// relationship, an index or a <c>HasData</c> call elsewhere maps it again on the application path, which
+    /// undoes the gate without saying so. That includes a navigation <em>to</em> the gated type from a mapped
+    /// entity: EF discovers it and brings the type back, so hold the navigation property back until the
+    /// release that uses the table, exactly as you would hold back a column.
+    /// </para>
+    /// <para>
+    /// ⚠️ <strong>A <c>DbSet&lt;TEntity&gt;</c> property belongs to the release that uses the table, not the
+    /// release that ships it.</strong> Declaring one while the type is gated compiles and builds a model;
+    /// touching it throws <em>"Cannot create a DbSet for 'TEntity' because this type is not included in the
+    /// model for the context"</em> on first use.
+    /// </para>
+    /// <para>
+    /// ⚠️ <strong>Not for a type in an inheritance hierarchy.</strong> Ignoring a base type rebases its
+    /// derived types onto their grandparent, and a discriminator value configured on the base resurrects a
+    /// gated derived type. Gate the columns instead.
+    /// </para>
+    /// </summary>
+    /// <param name="modelBuilder">The builder <c>OnModelCreating</c> was handed.</param>
+    /// <param name="context">The context being built — pass <c>this</c>.</param>
+    /// <param name="configure">
+    /// The table's own configuration, exactly as it would be written inside <c>Entity&lt;TEntity&gt;()</c>.
+    /// Omit it for a table EF's conventions already map correctly.
+    /// </param>
+    public static ModelBuilder MigrationsOnly<TEntity>(
+        this ModelBuilder modelBuilder,
+        DbContext context,
+        Action<EntityTypeBuilder<TEntity>>? configure = null)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return MigrationsOnlyEntity(modelBuilder, context.IsMigrationsModel(), configure);
+    }
+
+    /// <inheritdoc cref="MigrationsOnly{TEntity}(ModelBuilder, DbContext, Action{EntityTypeBuilder{TEntity}})"/>
+    /// <remarks>
+    /// For a context that would rather capture the answer in its constructor, and for an
+    /// <c>IEntityTypeConfiguration&lt;T&gt;</c>, which is handed a builder and never the context.
+    /// </remarks>
+    public static ModelBuilder MigrationsOnly<TEntity>(
+        this ModelBuilder modelBuilder,
+        DbContextOptions options,
+        Action<EntityTypeBuilder<TEntity>>? configure = null)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return MigrationsOnlyEntity(modelBuilder, options.IsMigrationsModel(), configure);
+    }
+
+    /// <summary>
+    /// Maps one property in the migrations model and hides it from the application model, for a column being
+    /// shipped a release ahead of the code that writes it.
+    /// <para>
+    /// <paramref name="configure"/> runs on the migration path only, for the same reason as the table
+    /// overload: the application model has no mapped property to configure.
+    /// </para>
+    /// <para>
+    /// ⚠️ <strong>A gated column may not be named by a key, an index or a foreign key configured outside this
+    /// call.</strong> If that configuration is <em>above</em> the gate, the column is already mapped
+    /// explicitly and the gate does nothing at all — no exception, no partial removal, the application model
+    /// simply keeps the column. EF does report it, as
+    /// <c>MappedPropertyIgnoredWarning</c> naming the member, which is why escalating that warning is worth
+    /// doing. If it is <em>below</em> the gate, the column comes back and nothing is reported. Either way, use
+    /// the overload taking a list of members, which puts all of it inside the gate.
+    /// </para>
+    /// <para>
+    /// ⚠️ <strong>Unlike a gated table, a gated column is silent when it outlives its release.</strong>
+    /// <c>Set&lt;T&gt;()</c> throws for a table the model does not have; a property the model does not have
+    /// still exists on the class, so reads return the default and writes are never persisted. Adding a column
+    /// is the more common change, so the quieter failure is also the more likely one.
+    /// </para>
+    /// </summary>
+    /// <param name="entityTypeBuilder">The builder for the entity the column belongs to.</param>
+    /// <param name="context">The context being built — pass <c>this</c>.</param>
+    /// <param name="propertyExpression">
+    /// A plain property access on the entity, such as <c>entity =&gt; entity.NewColumn</c>.
+    /// </param>
+    /// <param name="configure">
+    /// The column's own configuration, exactly as it would be chained onto <c>Property(...)</c>. Omit it for a
+    /// column EF's conventions already map correctly.
+    /// </param>
+    public static EntityTypeBuilder<TEntity> MigrationsOnly<TEntity, TProperty>(
+        this EntityTypeBuilder<TEntity> entityTypeBuilder,
+        DbContext context,
+        Expression<Func<TEntity, TProperty>> propertyExpression,
+        Action<PropertyBuilder<TProperty>>? configure = null)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return MigrationsOnlyProperty(entityTypeBuilder, context.IsMigrationsModel(), propertyExpression, configure);
+    }
+
+    /// <inheritdoc cref="MigrationsOnly{TEntity, TProperty}(EntityTypeBuilder{TEntity}, DbContext, Expression{Func{TEntity, TProperty}}, Action{PropertyBuilder{TProperty}})"/>
+    /// <remarks>
+    /// For a context that would rather capture the answer in its constructor, and for an
+    /// <c>IEntityTypeConfiguration&lt;T&gt;</c>, which is handed a builder and never the context.
+    /// </remarks>
+    public static EntityTypeBuilder<TEntity> MigrationsOnly<TEntity, TProperty>(
+        this EntityTypeBuilder<TEntity> entityTypeBuilder,
+        DbContextOptions options,
+        Expression<Func<TEntity, TProperty>> propertyExpression,
+        Action<PropertyBuilder<TProperty>>? configure = null)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return MigrationsOnlyProperty(entityTypeBuilder, options.IsMigrationsModel(), propertyExpression, configure);
+    }
+
+    /// <summary>
+    /// Hides several members at once, and runs <paramref name="configure"/> against the whole entity on the
+    /// migration path — for everything the single-property overload cannot reach, because <c>HasIndex</c>,
+    /// <c>HasKey</c>, <c>HasOne</c> and <c>HasData</c> live on the entity builder rather than on a property
+    /// builder.
+    /// <para>
+    /// This is where an index on a gated column belongs, and where a foreign key belongs together with the
+    /// navigation that goes with it — both gated, both configured, in one call that cannot be split apart or
+    /// reordered.
+    /// </para>
+    /// <example>
+    /// <code>
+    /// thing.MigrationsOnly(
+    ///     this,
+    ///     [entity =&gt; entity.CustomerId, entity =&gt; entity.Customer],
+    ///     gated =&gt;
+    ///     {
+    ///         gated.HasOne(entity =&gt; entity.Customer)
+    ///              .WithMany()
+    ///              .HasForeignKey(entity =&gt; entity.CustomerId);
+    ///
+    ///         gated.HasIndex(entity =&gt; entity.CustomerId);
+    ///     });
+    /// </code>
+    /// </example>
+    /// </summary>
+    /// <param name="entityTypeBuilder">The builder for the entity the members belong to.</param>
+    /// <param name="context">The context being built — pass <c>this</c>.</param>
+    /// <param name="members">
+    /// Plain member accesses on the entity, such as <c>[entity =&gt; entity.NewColumn]</c>. Scalars and
+    /// navigations both work; every member named here is hidden from the application model.
+    /// </param>
+    /// <param name="configure">
+    /// Configuration for the gated members, run on the migration path only. Anything it touches that is
+    /// <em>not</em> in <paramref name="members"/> keeps whatever the application model gave it, so keep it to
+    /// the gated members and what binds them together.
+    /// </param>
+    public static EntityTypeBuilder<TEntity> MigrationsOnly<TEntity>(
+        this EntityTypeBuilder<TEntity> entityTypeBuilder,
+        DbContext context,
+        IReadOnlyList<Expression<Func<TEntity, object?>>> members,
+        Action<EntityTypeBuilder<TEntity>>? configure = null)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return MigrationsOnlyMembers(entityTypeBuilder, context.IsMigrationsModel(), members, configure);
+    }
+
+    /// <inheritdoc cref="MigrationsOnly{TEntity}(EntityTypeBuilder{TEntity}, DbContext, IReadOnlyList{Expression{Func{TEntity, object}}}, Action{EntityTypeBuilder{TEntity}})"/>
+    /// <remarks>
+    /// For a context that would rather capture the answer in its constructor, and for an
+    /// <c>IEntityTypeConfiguration&lt;T&gt;</c>, which is handed a builder and never the context.
+    /// </remarks>
+    public static EntityTypeBuilder<TEntity> MigrationsOnly<TEntity>(
+        this EntityTypeBuilder<TEntity> entityTypeBuilder,
+        DbContextOptions options,
+        IReadOnlyList<Expression<Func<TEntity, object?>>> members,
+        Action<EntityTypeBuilder<TEntity>>? configure = null)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return MigrationsOnlyMembers(entityTypeBuilder, options.IsMigrationsModel(), members, configure);
+    }
+
+    private static ModelBuilder MigrationsOnlyEntity<TEntity>(
+        ModelBuilder modelBuilder,
+        bool isMigrationsModel,
+        Action<EntityTypeBuilder<TEntity>>? configure)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+
+        if (isMigrationsModel)
+        {
+            // Entity<TEntity>() first and unconditionally: folded into `configure?.Invoke(...)` it would not
+            // run at all when no delegate was given, and the table would be missing from the model that is
+            // supposed to have it.
+            var entityTypeBuilder = modelBuilder.Entity<TEntity>();
+
+            configure?.Invoke(entityTypeBuilder);
+
+            return modelBuilder;
+        }
+
+        // Nothing is mapped first. EF discovers the type from its DbSet property before OnModelCreating runs,
+        // but that discovery is not explicit configuration, so ignoring it here removes it outright - and,
+        // unlike a map-then-ignore, it does not report MappedEntityTypeIgnoredWarning on every model build.
+        modelBuilder.Ignore<TEntity>();
+
+        return modelBuilder;
+    }
+
+    private static EntityTypeBuilder<TEntity> MigrationsOnlyProperty<TEntity, TProperty>(
+        EntityTypeBuilder<TEntity> entityTypeBuilder,
+        bool isMigrationsModel,
+        Expression<Func<TEntity, TProperty>> propertyExpression,
+        Action<PropertyBuilder<TProperty>>? configure)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(entityTypeBuilder);
+        ArgumentNullException.ThrowIfNull(propertyExpression);
+
+        if (isMigrationsModel)
+        {
+            // Property(...) first and unconditionally, for the same reason as the table overload: inside
+            // `configure?.Invoke(...)` it would be skipped whenever no delegate was given.
+            var propertyBuilder = entityTypeBuilder.Property(propertyExpression);
+
+            configure?.Invoke(propertyBuilder);
+
+            return entityTypeBuilder;
+        }
+
+        var name = MemberName(propertyExpression);
+
+        // A navigation reaches this overload as a TProperty that happens to be an entity type, and the
+        // migration path would then fail inside Property() with EF's own message while the application path
+        // quietly succeeded - a difference between the two models produced by the gate itself.
+        if (entityTypeBuilder.Metadata.FindNavigation(name) is not null
+            || entityTypeBuilder.Metadata.FindSkipNavigation(name) is not null)
+        {
+            throw new ArgumentException(
+                $"'{name}' is a navigation, not a column, so it needs the overload that takes a list of "
+                + "members and configures the relationship on the migration path. Gate the foreign key "
+                + "property in the same call.",
+                nameof(propertyExpression));
+        }
+
+        // By name rather than by the expression: the Ignore overload taking one wants
+        // Expression<Func<TEntity, object?>>, while Property() wants the typed expression that keeps
+        // PropertyBuilder<TProperty> typed for the caller. One of the two has to give, and this is the half
+        // that costs nothing.
+        entityTypeBuilder.Ignore(name);
+
+        return entityTypeBuilder;
+    }
+
+    private static EntityTypeBuilder<TEntity> MigrationsOnlyMembers<TEntity>(
+        EntityTypeBuilder<TEntity> entityTypeBuilder,
+        bool isMigrationsModel,
+        IReadOnlyList<Expression<Func<TEntity, object?>>> members,
+        Action<EntityTypeBuilder<TEntity>>? configure)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(entityTypeBuilder);
+        ArgumentNullException.ThrowIfNull(members);
+
+        if (members.Count == 0)
+        {
+            throw new ArgumentException(
+                "Name at least one member to hide from the application model. A call that gates nothing "
+                + "configures the migrations model alone, which puts the two models out of step in the "
+                + "direction this package exists to prevent.",
+                nameof(members));
+        }
+
+        // Every name first, so a bad expression is reported before half the members have been ignored.
+        var names = new string[members.Count];
+
+        for (var index = 0; index < members.Count; index++)
+        {
+            names[index] = MemberName(members[index]);
+        }
+
+        if (isMigrationsModel)
+        {
+            configure?.Invoke(entityTypeBuilder);
+
+            return entityTypeBuilder;
+        }
+
+        foreach (var name in names)
+        {
+            entityTypeBuilder.Ignore(name);
+        }
+
+        return entityTypeBuilder;
+    }
+
+    /// <summary>
+    /// The name of the member an <c>entity =&gt; entity.Something</c> expression reads.
+    /// </summary>
+    private static string MemberName<TEntity, TMember>(Expression<Func<TEntity, TMember>> memberExpression)
+    {
+        ArgumentNullException.ThrowIfNull(memberExpression);
+
+        var body = memberExpression.Body;
+
+        // A value-typed member reached through a Func<TEntity, object?> arrives wrapped in a conversion the
+        // compiler inserted. Nothing else about the expression changes.
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } conversion)
+        {
+            body = conversion.Operand;
+        }
+
+        if (body is MemberExpression { Expression.NodeType: ExpressionType.Parameter } member)
+        {
+            return member.Member.Name;
+        }
+
+        throw new ArgumentException(
+            "MigrationsOnly needs a plain member access on the entity, such as 'entity => entity.NewColumn'. "
+            + $"'{memberExpression}' reaches further than that, and gating a member of an owned or complex "
+            + "type is not something these methods do.",
+            nameof(memberExpression));
+    }
+}

--- a/src/version.props
+++ b/src/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.0.48</Version>
+    <Version>2.1.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Likvido/Likvido.DbMigrator.EfCore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Closes Likvido/Likvido.App#28174.

When we change a database schema, the change ships across two releases so that old and new code both keep working whatever the database looks like at that moment. Until now the small piece of code that hides the new table or column from the running application was hand-written, and there were several ways to write it that compile, look correct in review, and quietly break something. This makes the package write that piece instead, so most of those ways stop existing.

## What changed

<details>
<summary>See here</summary>

### `MigrationsOnly` replaces the hand-written condition

The gate takes the member's own configuration as a delegate, so the mapping and the ignore are one call and the call decides the order:

```csharp
modelBuilder.MigrationsOnly<Gadget>(this, gadget =>
{
    gadget.ToTable("Gadgets");
    gadget.HasKey(x => x.Id);
});

modelBuilder.Entity<Thing>(thing =>
{
    thing.MigrationsOnly(this, x => x.NewColumn, column => column.HasMaxLength(50));

    thing.MigrationsOnly(
        this,
        [x => x.CustomerId, x => x.Customer],
        gated =>
        {
            gated.HasOne(x => x.Customer).WithMany().HasForeignKey(x => x.CustomerId);
            gated.HasIndex(x => x.CustomerId);
        });
});
```

Three shapes, each with a `DbContext` and a `DbContextOptions` overload — the latter because most of the estate maps through `IEntityTypeConfiguration<T>` classes, which are handed a builder and never the context.

All three ways of getting the hand-written form wrong become unwritable: ungated, inverted, and placed above the mapping it is meant to hide. Where the call sits in `OnModelCreating` no longer matters.

Release 2 replaces each call with the ordinary EF one and needs no migration. A removal runs the same edit backwards — turn the ordinary call into a `MigrationsOnly` one in the release that stops using the member, delete it in the release after — so everything outstanding in a repository is one `grep MigrationsOnly`.

### The list overload, instead of a separate escape hatch

`Action<PropertyBuilder<T>>` cannot reach `HasIndex`, `HasKey`, `HasOne` or `HasData`. A separate method that ran a migrations-only block *without* ignoring anything would have looked like a gate while not being one — the property would still be discovered by convention on the application path — so the third overload takes the members to hide and configures them against the entity builder in the same call.

### `MigrationsModelDiagnostics`

The one invariant a consumer should assert — the migrations model is never missing what the application model has — packaged, because the hand-rolled copy in `Likvido.Agents` compares the properties of a single entity type while reading as though it compared them all. It refuses a comparison that cannot fail rather than returning an empty list.

### Item 2 of the issue is dropped, not spiked

The issue proposed applying the ignore from an `IModelFinalizingConvention` so placement would stop mattering. The gate applies on the *application* path, which by definition carries no `MigrationsModelExtension`, so the convention could not be registered through the options extension at all — it would have needed a mandatory `ConfigureConventions` override in every consumer context, a fresh way to fail silently in exchange for the two mistakes the delegate already removes.

</details>

## What testing turned up

<details>
<summary>See here</summary>

Verified on EF Core 10.0.11, and each of these is now a test.

**A design review predicted that gating a foreign key from outside its gate leaves a renamed shadow column behind. That is wrong.** The gate simply does nothing at all: the column, the foreign key and the navigation all stay, because an explicit mapping cannot be removed by ignoring it afterwards while a foreign key is still using it. The docs say the measured thing rather than the predicted one.

**EF already reports that case**, as `MappedPropertyIgnoredWarning` naming the exact member. A model built through `MigrationsOnly` never maps a member before ignoring it, so that warning never fires in the healthy case — which leaves it free to mean something:

```csharp
options.ConfigureWarnings(warnings => warnings.Throw(
    CoreEventId.MappedPropertyIgnoredWarning,
    CoreEventId.MappedEntityTypeIgnoredWarning));
```

It also catches anyone reverting to the hand-written form, which maps and then ignores.

**Configuration placed *after* a gate stays silent**, even with every ignore-related warning escalated — EF sees a mapping and no ignore, so it has no opinion. What catches that is the first query against a column the migration has not created yet. This is the residual limit, and it is stated as such in the docs rather than glossed over.

**One bug in the first cut, caught by the test for an omitted delegate.** `configure?.Invoke(modelBuilder.Entity<T>())` never evaluates `Entity<T>()` when `configure` is null, so a gated table with no configuration was missing from the model that has to have it.

53 tests, including a control for every separation claim, the two hand-written mistakes kept as fixtures so the suite states what the API replaces, and the `DbSet` of a gated table throwing the way it did in staging.

</details>

## Notes for review

<details>
<summary>See here</summary>

- `version.props` goes to **2.1.0**, which publishes both `Likvido.EfCore.MigrationsModel` and `Likvido.DbMigrator.EfCore` — they share one version by design.
- Package dependencies are unchanged: EF Core and nothing else, verified against the packed nuspec.
- `MigrationsModelExtension` is untouched, so it stays the pure marker its doc comment describes and the model-cache separation is unaffected.
- `IsMigrationsModel()` stays public and documented, for the one thing the gate cannot express: configuration that has to *differ* between the two models rather than be absent from one of them. A global query filter over a gated column is the real case — moved inside a gate it would leave the application with no filter at all.
- Nothing in the estate has a live gate right now, so there is no working code to migrate. `Likvido.Agents` adopts the package version in its own PR once 2.1.0 is published; the NewWiki article is rewritten in a parallel PR that merges after publish.
- Gated navigations and owned/complex types are out of scope, and the XML docs say so. Nothing anywhere in the estate uses `OwnsOne`, `OwnsMany` or `ComplexProperty`.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `MigrationsOnly` helpers for including tables, columns, indexes, keys, relationships, and seed data exclusively in migration models.
  - Added diagnostics for identifying entities and properties missing from migration models.
  - Added validation for invalid configurations and unsupported references.

- **Documentation**
  - Updated migration workflow guidance with expand/contract release examples and configuration recommendations.

- **Tests**
  - Expanded coverage for gating behavior, diagnostics, relationships, indexes, ordering, and argument validation.

- **Release**
  - Updated version to 2.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->